### PR TITLE
Fix human stencil UV is flipped

### DIFF
--- a/Packages/com.github.asus4.arfoundationreplay/Resources/Shaders/Common.hlsl
+++ b/Packages/com.github.asus4.arfoundationreplay/Resources/Shaders/Common.hlsl
@@ -72,9 +72,9 @@ float DecodeDepth(float3 rgb, float2 range)
 // UV coordinate remapping functions
 //
 // +-----+-----+  C: Color
-// |  Z  |     |  Z: Hue-encoded depth
-// +-----+  C  |  S: Human stencil
-// | S/M |     |  M: Metadata
+// |  S  |     |  S: Human stencil
+// +-----+  C  |  Z: Hue-encoded depth
+// |  Z  |     |  
 // +-----+-----+
 //
 

--- a/Packages/com.github.asus4.arfoundationreplay/Resources/Shaders/Common.hlsl
+++ b/Packages/com.github.asus4.arfoundationreplay/Resources/Shaders/Common.hlsl
@@ -99,7 +99,7 @@ float2 UV_FullToColor(float2 uv)
 float2 UV_StencilToFull(float2 uv)
 {
     return float2(
-        lerp(0.5, 0.0, uv.x),
+        lerp(0.0, 0.5, uv.x),
         lerp(1.0, 0.5, uv.y)
     );
 }

--- a/Packages/com.github.asus4.arfoundationreplay/Runtime/Internal/Encoders/TrackableChangesPacket.cs
+++ b/Packages/com.github.asus4.arfoundationreplay/Runtime/Internal/Encoders/TrackableChangesPacket.cs
@@ -142,7 +142,8 @@ namespace ARFoundationReplay
 
     internal static class TrackableChangesPacketExtension
     {
-        public delegate bool TrackableFilter<T>(ref T trackable);
+        public delegate bool TrackableFilter<T>(ref T trackable)
+            where T : struct, ITrackable;
 
         /// <summary>
         /// Used while replaying packets.


### PR DESCRIPTION
Fix human stencil UV is flipped while decoding in Unity Editor