### PR TITLE
Fix ARCoreRecorder serialization mismatch on Unity 6.3

### DIFF
--- a/Packages/com.github.asus4.arfoundationreplay/Runtime/Recorder/ARCoreRecorder.cs
+++ b/Packages/com.github.asus4.arfoundationreplay/Runtime/Recorder/ARCoreRecorder.cs
@@ -147,6 +147,10 @@ namespace ARFoundationReplay
     /// </summary>
     public class ARCoreRecorder : MonoBehaviour, IRecorder
     {
+        // Keep same serialized fields as Android version for Unity serialization compatibility
+        [SerializeField]
+        private ARSession _session = null;
+
         public bool IsRecording => false;
 
         public void StartRecording()


### PR DESCRIPTION
## Problem

When building for Android on Unity 6.3 (6000.3.x), the build fails with:

```
Type '[ARFoundationReplay]ARFoundationReplay.ARCoreRecorder' has an extra field '_session' of type 'UnityEngine.XR.ARFoundation.ARSession' in the player and thus can't be serialized

Error building player because script class layout is incompatible between the editor and the player.
```

## Cause

The `ARCoreRecorder` class has different serialized fields between the `#if UNITY_ANDROID` and `#else` branches:

- Android version: has `[SerializeField] private ARSession _session`
- Non-Android version: no `_session` field

Unity 6.3 has stricter serialization checks, causing a mismatch between Editor and Player builds.

## Solution

Add the `_session` field to the non-Android version to ensure consistent serialization layout across all platforms.

## Testing

- Tested on Unity 6000.3.6f1 with AR Foundation 6.3.2
- Android build and runtime verified working on Pixel 8